### PR TITLE
Fix obsolete warnings

### DIFF
--- a/Assets/TheLabRenderer/Editor/ValveAutoUpdateSettings.cs
+++ b/Assets/TheLabRenderer/Editor/ValveAutoUpdateSettings.cs
@@ -250,7 +250,11 @@ public class TheLabRenderer_Settings : EditorWindow
 
 			if (GUILayout.Button(string.Format(useRecommended, recommended_BuildTarget)))
 			{
+				#if UNITY_5_4 || UNITY_5_5
 				EditorUserBuildSettings.SwitchActiveBuildTarget(recommended_BuildTarget);
+				#else
+				EditorUserBuildSettings.SwitchActiveBuildTarget(BuildPipeline.GetBuildTargetGroup(recommended_BuildTarget), recommended_BuildTarget);
+				#endif
 			}
 
 			GUILayout.FlexibleSpace();
@@ -642,7 +646,11 @@ public class TheLabRenderer_Settings : EditorWindow
 			{
 				// Only set those that have not been explicitly ignored.
 				if (!EditorPrefs.HasKey(ignore + buildTarget))
+					#if UNITY_5_4 || UNITY_5_5
 					EditorUserBuildSettings.SwitchActiveBuildTarget(recommended_BuildTarget);
+					#else
+					EditorUserBuildSettings.SwitchActiveBuildTarget(BuildPipeline.GetBuildTargetGroup(recommended_BuildTarget), recommended_BuildTarget);
+					#endif
 				if (!EditorPrefs.HasKey(ignore + showUnitySplashScreen))
 					showUnitySplashScreenPlayerSetting = recommended_ShowUnitySplashScreen;
 				if (!EditorPrefs.HasKey(ignore + defaultIsFullScreen))

--- a/Assets/TheLabRenderer/Editor/ValveAutoUpdateSettings.cs
+++ b/Assets/TheLabRenderer/Editor/ValveAutoUpdateSettings.cs
@@ -61,13 +61,30 @@ public class TheLabRenderer_Settings : EditorWindow
 		EditorApplication.update += Update;
 	}
 
+	static bool showUnitySplashScreenPlayerSetting{
+		get{
+			#if UNITY_5_4
+				return PlayerSettings.showUnitySplashScreen;
+			#else
+				return PlayerSettings.SplashScreen.show;
+			#endif
+		}
+		set{
+			#if UNITY_5_4
+				PlayerSettings.showUnitySplashScreen = value;
+			#else
+				PlayerSettings.SplashScreen.show = value;
+			#endif
+		}
+	}
+
 	static void Update()
 	{
 		bool show =
 			(!EditorPrefs.HasKey(ignore + buildTarget) &&
 				EditorUserBuildSettings.activeBuildTarget != recommended_BuildTarget) ||
 			(!EditorPrefs.HasKey(ignore + showUnitySplashScreen) &&
-				PlayerSettings.showUnitySplashScreen != recommended_ShowUnitySplashScreen) ||
+				showUnitySplashScreenPlayerSetting != recommended_ShowUnitySplashScreen) ||
 			(!EditorPrefs.HasKey(ignore + defaultIsFullScreen) &&
 				PlayerSettings.defaultIsFullScreen != recommended_DefaultIsFullScreen) ||
 			(!EditorPrefs.HasKey(ignore + defaultScreenSize) &&
@@ -214,17 +231,17 @@ public class TheLabRenderer_Settings : EditorWindow
 		}
 
 		if (!EditorPrefs.HasKey(ignore + showUnitySplashScreen) &&
-			PlayerSettings.showUnitySplashScreen != recommended_ShowUnitySplashScreen)
+			showUnitySplashScreenPlayerSetting != recommended_ShowUnitySplashScreen)
 		{
 			++numItems;
 
-			GUILayout.Label(showUnitySplashScreen + string.Format(currentValue, PlayerSettings.showUnitySplashScreen));
+			GUILayout.Label(showUnitySplashScreen + string.Format(currentValue, showUnitySplashScreenPlayerSetting));
 
 			GUILayout.BeginHorizontal();
 
 			if (GUILayout.Button(string.Format(useRecommended, recommended_ShowUnitySplashScreen)))
 			{
-				PlayerSettings.showUnitySplashScreen = recommended_ShowUnitySplashScreen;
+				showUnitySplashScreenPlayerSetting = recommended_ShowUnitySplashScreen;
 			}
 
 			GUILayout.FlexibleSpace();
@@ -594,7 +611,7 @@ public class TheLabRenderer_Settings : EditorWindow
 				if (!EditorPrefs.HasKey(ignore + buildTarget))
 					EditorUserBuildSettings.SwitchActiveBuildTarget(recommended_BuildTarget);
 				if (!EditorPrefs.HasKey(ignore + showUnitySplashScreen))
-					PlayerSettings.showUnitySplashScreen = recommended_ShowUnitySplashScreen;
+					showUnitySplashScreenPlayerSetting = recommended_ShowUnitySplashScreen;
 				if (!EditorPrefs.HasKey(ignore + defaultIsFullScreen))
 					PlayerSettings.defaultIsFullScreen = recommended_DefaultIsFullScreen;
 				if (!EditorPrefs.HasKey(ignore + defaultScreenSize))
@@ -639,7 +656,7 @@ public class TheLabRenderer_Settings : EditorWindow
 					// Only ignore those that do not currently match our recommended settings.
 					if (EditorUserBuildSettings.activeBuildTarget != recommended_BuildTarget)
 						EditorPrefs.SetBool(ignore + buildTarget, true);
-					if (PlayerSettings.showUnitySplashScreen != recommended_ShowUnitySplashScreen)
+					if (showUnitySplashScreenPlayerSetting != recommended_ShowUnitySplashScreen)
 						EditorPrefs.SetBool(ignore + showUnitySplashScreen, true);
 					if (PlayerSettings.defaultIsFullScreen != recommended_DefaultIsFullScreen)
 						EditorPrefs.SetBool(ignore + defaultIsFullScreen, true);

--- a/Assets/TheLabRenderer/Editor/ValveAutoUpdateSettings.cs
+++ b/Assets/TheLabRenderer/Editor/ValveAutoUpdateSettings.cs
@@ -157,7 +157,11 @@ public class TheLabRenderer_Settings : EditorWindow
 			updated = true;
 		}
 
+		#if UNITY_5_4
 		var devices = UnityEditorInternal.VR.VREditor.GetVREnabledDevices(BuildTargetGroup.Standalone);
+		#else
+		var devices = UnityEditorInternal.VR.VREditor.GetVREnabledDevicesOnTargetGroup(BuildTargetGroup.Standalone);
+		#endif
 		var hasOpenVR = false;
 		foreach (var device in devices)
 			if (device.ToLower() == "openvr")
@@ -178,7 +182,11 @@ public class TheLabRenderer_Settings : EditorWindow
 				newDevices[devices.Length] = "OpenVR";
 				updated = true;
 			}
+			#if UNITY_5_4
 			UnityEditorInternal.VR.VREditor.SetVREnabledDevices(BuildTargetGroup.Standalone, newDevices);
+			#else
+			UnityEditorInternal.VR.VREditor.SetVREnabledDevicesOnTargetGroup(BuildTargetGroup.Standalone, newDevices);
+			#endif
 		}
 
 		if (updated)

--- a/Assets/TheLabRenderer/Editor/ValveMenuTools.cs
+++ b/Assets/TheLabRenderer/Editor/ValveMenuTools.cs
@@ -182,7 +182,7 @@ public class ValveMenuTools
 					m.renderQueue = 3000;
 				}
 			}
-			
+
 			return true;
 		}
 		else if ( bRecordUnknownShaders )
@@ -399,7 +399,6 @@ public class ValveMenuTools
 	}
 
 	//---------------------------------------------------------------------------------------------------------------------------------------------------
-	[UnityEditor.MenuItem( "Valve/Shader Dev/Convert All Materials Back to Unity Shaders", false, 101 )]
 	private static void ValveToStandard( bool bConvertAllMaterials )
 	{
 		int nNumMaterialsConverted = 0;

--- a/Assets/TheLabRenderer/Scripts/ValveCamera.cs
+++ b/Assets/TheLabRenderer/Scripts/ValveCamera.cs
@@ -391,7 +391,7 @@ public class ValveCamera : MonoBehaviour
 			var timing = new Valve.VRRenderingPackage.Compositor_FrameTiming();
 			timing.m_nSize = ( uint )System.Runtime.InteropServices.Marshal.SizeOf( typeof( Valve.VRRenderingPackage.Compositor_FrameTiming ) );
 			Valve.VRRenderingPackage.OpenVR.Compositor.GetFrameTiming( ref timing, 0 );
-		
+
 			if ( timing.m_nNumFramePresents > 1 )
 				return;
 		}
@@ -449,7 +449,7 @@ public class ValveCamera : MonoBehaviour
 		//{
 		//	ValveShadowBufferRender();
 		//}
-		#if UNITY_5_5 || UNITY_5_6
+		#if UNITY_5_5 || UNITY_5_6_OR_NEWER
 			UpdateAdaptiveQuality();
 		#endif
 		// Adaptive quality debug quad
@@ -498,7 +498,6 @@ public class ValveCamera : MonoBehaviour
 				{
 					0, 1, 2, 0, 2, 3
 				};
-				mesh.Optimize();
 				mesh.UploadMeshData( false );
 
 				m_adaptiveQualityDebugQuad = new GameObject( "AdaptiveQualityDebugQuad" );
@@ -631,6 +630,20 @@ public class ValveCamera : MonoBehaviour
 		}
 	}
 
+	static public float gpuTimeLastFrame{
+		get{
+			float last = 0f;
+			#if UNITY_5_4 || UNITY_5_5
+				last = VRStats.gpuTimeLastFrame;
+			#elif UNITY_5_6 || UNITY_2017_1
+				VRStats.TryGetGPUTimeLastFrame(out last);
+			#else
+				XRStats.TryGetGPUTimeLastFrame(out last);
+			#endif
+			return last;
+		}
+	}
+
 	[NonSerialized] private int m_nLastQualityFrameCount = -1;
 	void UpdateAdaptiveQuality()
 	{
@@ -657,7 +670,7 @@ public class ValveCamera : MonoBehaviour
 		// Add latest timing to ring buffer
 		int nRingBufferSize = m_adaptiveQualityRingBuffer.GetLength( 0 );
 		m_nAdaptiveQualityRingBufferPos = ( m_nAdaptiveQualityRingBufferPos + 1 ) % nRingBufferSize;
-		m_adaptiveQualityRingBuffer[ m_nAdaptiveQualityRingBufferPos ] = VRStats.gpuTimeLastFrame;
+		m_adaptiveQualityRingBuffer[ m_nAdaptiveQualityRingBufferPos ] = gpuTimeLastFrame;
 
 		int nOldQualityLevel = m_nAdaptiveQualityLevel;
 		float flSingleFrameMs = ( VRDevice.refreshRate > 0.0f ) ? ( 1000.0f / VRDevice.refreshRate ) : ( 1000.0f / 90.0f ); // Assume 90 fps
@@ -823,7 +836,7 @@ public class ValveCamera : MonoBehaviour
 		Shader.SetGlobalInt( "g_nNumBins", m_adaptiveQualityNumLevels );
 		Shader.SetGlobalInt( "g_nDefaultBin", m_adaptiveQualityDefaultLevel );
 		Shader.SetGlobalInt( "g_nCurrentBin", nAdaptiveQualityLevel );
-		Shader.SetGlobalInt( "g_nLastFrameInBudget", m_bInterleavedReprojectionEnabled || ( VRStats.gpuTimeLastFrame > flSingleFrameMs ) ? 0 : 1 );
+		Shader.SetGlobalInt( "g_nLastFrameInBudget", m_bInterleavedReprojectionEnabled || ( gpuTimeLastFrame > flSingleFrameMs ) ? 0 : 1 );
 	}
 
 	//---------------------------------------------------------------------------------------------------------------------------------------------------
@@ -1055,7 +1068,7 @@ public class ValveCamera : MonoBehaviour
 					Vector3 vLightRight = lightTransform.right;
 					Vector3 vLightUp = lightTransform.up;
 					float flSpotAngle = l.spotAngle;
-					
+
 					// Passed the AABB test
 					vl.m_bInCameraFrustum = true;
 
@@ -1384,7 +1397,7 @@ public class ValveCamera : MonoBehaviour
 				nNumLightsIncludingTooMany++;
 				if ( nNumLightsIncludingTooMany > MAX_LIGHTS )
 					continue;
-				
+
 				float flIntensity = ( l.intensity <= 1.0f ) ? l.intensity : l.intensity * l.intensity;
 				g_vLightColor[ g_nNumLights ] = new Vector4( l.color.linear.r * flIntensity, l.color.linear.g * flIntensity, l.color.linear.b * flIntensity );
 				g_vLightPosition_flInvRadius[ g_nNumLights ] = new Vector4( l.transform.position.x, l.transform.position.y, l.transform.position.z, 1.0f / l.range );

--- a/Assets/TheLabRenderer/Scripts/ValveCamera.cs
+++ b/Assets/TheLabRenderer/Scripts/ValveCamera.cs
@@ -17,6 +17,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using UnityEngine.VR;
+#if UNITY_2017_2
+	using UnityEngine.XR;
+#endif
 #if ( UNITY_EDITOR )
 	using UnityEditor;
 #endif


### PR DESCRIPTION
I was annoyed by the warnings in the console every time I build. So I fixed them.
I only tested this in unity 2017.1.1f1 so I'm not sure if it's working in older versions, but I did use UNITY_X_Y defines.
Let me know if anything seems odd.